### PR TITLE
Implement json output via the -j flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-hauditor is a tool designed to analyze the security headers returned by a web page and report dangerous configurations. 
+hauditor is a tool designed to analyze the security headers returned by a web page and report dangerous configurations.
 
 
 ![hauditor Image](https://github.com/trap-bytes/hauditor/blob/main/static/hauditor.png)
@@ -39,9 +39,10 @@ The arguments are:
   -m string    HTTP method (HEAD, GET, POST, PUT, etc.)
   -b string    HTTP request body
   -p string    Specify the proxy URL (e.g., 127.0.0.1:8080)
-  -c string    Specify cookies (e.g., "user_token=g3p21ip21h;" 
+  -c string    Specify cookies (e.g., "user_token=g3p21ip21h;"
   -r string    Specify headers (e.g., "Myheader: test")
   -timeout     Timeout for HTTP requests in seconds
+  -j           Output in JSON format
   -h           Display help
 
 Examples:

--- a/auditor/auditor.go
+++ b/auditor/auditor.go
@@ -155,14 +155,14 @@ func checkDangerousSource(sources []string, directive string, response *HeaderRe
 							response.Status = Warning
 						}
 						response.ConsoleMessages = append(response.ConsoleMessages, utils.Colorize("Content-Security-Policy", "yellow", true)+" possible dangerous source in "+utils.Colorize(directive+": ", "", true)+"Make sure that "+utils.Colorize(source, "blue", true)+" is not hosting JSONP endpoints")
-						response.Messages = append(response.Messages, "Possible dangerous source in "+directive+": "+source+" is hosting JSONP endpoints.")
+						response.Messages = append(response.Messages, "Possible dangerous source in "+directive+": Make sure that "+source+" is not hosting JSONP endpoints.")
 					}
 				} else if nonHttpUrlPattern.MatchString(source) {
 					if response.Status != Error {
 						response.Status = Warning
 					}
 					response.ConsoleMessages = append(response.ConsoleMessages, utils.Colorize("Content-Security-Policy", "yellow", true)+" possible dangerous source in "+utils.Colorize(directive+": ", "", true)+"Make sure that "+utils.Colorize(source, "blue", true)+" is not hosting JSONP endpoints")
-					response.Messages = append(response.Messages, "Possible dangerous source in "+directive+": "+source+" is hosting JSONP endpoints.")
+					response.Messages = append(response.Messages, "Possible dangerous source in "+directive+": Make sure that "+source+" is not hosting JSONP endpoints.")
 				}
 			}
 		}

--- a/auditor/auditor.go
+++ b/auditor/auditor.go
@@ -1,7 +1,6 @@
 package auditor
 
 import (
-	"fmt"
 	"net/url"
 	"regexp"
 	"strings"
@@ -9,52 +8,80 @@ import (
 	"github.com/trap-bytes/hauditor/utils"
 )
 
-func xFrameOptionsAudit(resphdrs map[string][]string) {
+func xFrameOptionsAudit(resphdrs map[string][]string) HeaderResponse {
+	var response HeaderResponse = HeaderResponse{Header: XFrameOptionsHeader, Status: Success}
 
 	if _, ok := resphdrs[XFrameOptionsHeader]; !ok {
 		if _, ok := resphdrs[ContentSecurityPolicyHeader]; !ok {
-			fmt.Printf(utils.Colorize("X-Frame-Options", "red", true) + " header missing\n")
-			redissues++
+			response.Status = Error
+			response.ConsoleMessages = []string{utils.Colorize("X-Frame-Options", "red", true) + " header missing"}
+			response.Messages = []string{"X-Frame-Options header missing"}
 		} else if !strings.Contains(resphdrs[ContentSecurityPolicyHeader][0], "frame-ancestors") {
-			fmt.Printf(utils.Colorize("X-Frame-Options", "red", true) + " header missing\n")
-			redissues++
+			response.Status = Error
+			response.ConsoleMessages = []string{utils.Colorize("X-Frame-Options", "red", true) + " header missing"}
+			response.Messages = []string{"X-Frame-Options header missing"}
 		} else if !strings.Contains(resphdrs[ContentSecurityPolicyHeader][0], "frame-ancestors 'self'") && !strings.Contains(resphdrs[ContentSecurityPolicyHeader][0], "frame-ancestors 'none'") {
-			fmt.Print("Possibly insecure frame-ancestor value in " + utils.Colorize("Content-Security-Policy", "red", true) + " Header. Consider using 'none' or 'self'\n")
-			yellowissues++
+			response.Status = Warning
+			response.ConsoleMessages = []string{"Possibly insecure frame-ancestor value in " + utils.Colorize("Content-Security-Policy", "red", true) + " Header. Consider using 'none' or 'self'"}
+			response.Messages = []string{"Possibly insecure frame-ancestor value in Content-Security-Policy Header"}
 		}
 	} else if !strings.EqualFold(resphdrs[XFrameOptionsHeader][0], "DENY") && !strings.EqualFold(resphdrs[XFrameOptionsHeader][0], "SAMEORIGIN") {
-		fmt.Printf("Insecure "+utils.Colorize("X-Frame-Options", "red", true)+" header value: "+utils.Colorize("%s", "", true), resphdrs[XFrameOptionsHeader][0])
-		redissues++
+		response.Status = Error
+		response.ConsoleMessages = []string{"Insecure " + utils.Colorize("X-Frame-Options", "red", true) + " header value: " + utils.Colorize(resphdrs[XFrameOptionsHeader][0], "", true)}
+		response.Messages = []string{"Insecure X-Frame-Options header value: " + resphdrs[XFrameOptionsHeader][0]}
 	}
+
+	return response
 }
 
-func xContentTypeOptionsAudit(resphdrs map[string][]string) {
+func xContentTypeOptionsAudit(resphdrs map[string][]string) HeaderResponse {
+	var response HeaderResponse = HeaderResponse{Header: XContentTypeOptionsHeader, Status: Success}
+
 	if _, ok := resphdrs[XContentTypeOptionsHeader]; !ok {
-		fmt.Printf(utils.Colorize("X-Content-Type-Options", "red", true) + " header missing\n")
-		redissues++
+		response.Status = Error
+		response.ConsoleMessages = []string{utils.Colorize("X-Content-Type-Options", "red", true) + " header missing"}
+		response.Messages = []string{"X-Content-Type-Options header missing"}
 	} else if resphdrs[XContentTypeOptionsHeader][0] != "nosniff" {
-		fmt.Print("Insecure " + utils.Colorize("X-Content-Type-Options", "red", true) + " header. Consider using 'nosniff'\n")
-		redissues++
+		response.Status = Error
+		response.ConsoleMessages = []string{"Insecure " + utils.Colorize("X-Content-Type-Options", "red", true) + " header. Consider using 'nosniff'"}
+		response.Messages = []string{"Insecure X-Content-Type-Options header. Consider using 'nosniff'."}
 	}
+
+	return response
 }
 
-func strictTransportSecurityAudit(resphdrs map[string][]string) {
+func strictTransportSecurityAudit(resphdrs map[string][]string) HeaderResponse {
+	var response HeaderResponse = HeaderResponse{Header: StrictTransportSecurityHeader, Status: Success}
+
 	if _, ok := resphdrs[StrictTransportSecurityHeader]; !ok {
-		fmt.Printf(utils.Colorize("Strict-Transport-Security", "red", true) + " header missing\n")
-		redissues++
+		response.Status = Error
+		response.ConsoleMessages = []string{utils.Colorize("Strict-Transport-Security", "red", true) + " header missing"}
+		response.Messages = []string{"Strict-Transport-Security header missing"}
 	}
+
+	return response
 }
 
-func contentSecurityPolicyAudit(resphdrs map[string][]string) {
+func contentSecurityPolicyAudit(resphdrs map[string][]string) HeaderResponse {
+	var response HeaderResponse = HeaderResponse{
+		Header:          ContentSecurityPolicyHeader,
+		Status:          Success,
+		ConsoleMessages: []string{},
+		Messages:        []string{},
+	}
+
 	if _, ok := resphdrs[ContentSecurityPolicyHeader]; !ok {
-		fmt.Printf(utils.Colorize("Content-Security-Policy", "red", true) + " header missing\n")
-		redissues++
+		response.Status = Error
+		response.ConsoleMessages = []string{utils.Colorize("Content-Security-Policy", "red", true) + " header missing"}
+		response.Messages = []string{"Content-Security-Policy header missing"}
 	} else {
-		cspDirectiveAudit(resphdrs[ContentSecurityPolicyHeader])
+		cspDirectiveAudit(resphdrs[ContentSecurityPolicyHeader], &response)
 	}
+
+	return response
 }
 
-func cspDirectiveAudit(csp []string) {
+func cspDirectiveAudit(csp []string, response *HeaderResponse) {
 	var scriptSrc bool = false
 	var defaultSrc bool = false
 
@@ -63,7 +90,7 @@ func cspDirectiveAudit(csp []string) {
 	if values, ok := directives["script-src"]; ok {
 		scriptSrc = true
 		sources := strings.Fields(values)
-		checkDangerousSource(sources, "script-src")
+		checkDangerousSource(sources, "script-src", response)
 	}
 
 	if values, ok := directives["default-src"]; ok {
@@ -73,54 +100,69 @@ func cspDirectiveAudit(csp []string) {
 
 			for _, source := range sources {
 				if source == "*" {
-					fmt.Print(utils.Colorize("Content-Security-Policy", "red", true) + " dangerous source in " + utils.Colorize("default-src:", "", true) + " should not contain " + utils.Colorize("'*'", "magenta", true) + " as a source.\n")
-					redissues++
+					response.Status = Error
+					response.ConsoleMessages = append(response.ConsoleMessages, utils.Colorize("Content-Security-Policy", "red", true)+" dangerous source in "+utils.Colorize("default-src:", "", true)+" should not contain "+utils.Colorize("'*'", "magenta", true)+" as a source.")
+					response.Messages = append(response.Messages, "Dangerous source in default-src should not contain '*' as a source.")
 				}
 			}
 		} else { // if script-src is not defined, we need to be strict on default-src values since they'll be used as fallback for script-src
-			checkDangerousSource(sources, "default-src")
+			checkDangerousSource(sources, "default-src", response)
 		}
 	}
 
 	if !scriptSrc && !defaultSrc {
-		fmt.Print(utils.Colorize("Content-Security-Policy", "red", true) + " no " + utils.Colorize("script-src", "", true) + " directive defined, this could allow the execution of scripts from untrusted sources\n")
-		redissues++
+		response.Status = Error
+		response.ConsoleMessages = append(response.ConsoleMessages, utils.Colorize("Content-Security-Policy", "red", true)+" no "+utils.Colorize("script-src", "", true)+" directive defined, this could allow the execution of scripts from untrusted sources")
+		response.Messages = append(response.Messages, "No script-src directive defined, this could allow the execution of scripts from untrusted sources.")
 	}
 
 }
 
-func checkDangerousSource(sources []string, directive string) {
+func checkDangerousSource(sources []string, directive string, response *HeaderResponse) {
 	nonHttpUrlPattern := regexp.MustCompile(`^((\*|[a-zA-Z0-9.-]+)\.)+[a-zA-Z]{2,}$`)
 	for _, source := range sources {
 		switch source {
 		case "'unsafe-inline'":
-			fmt.Printf(utils.Colorize("Content-Security-Policy", "red", true)+" dangerous source in "+utils.Colorize("%s: ", "", true)+utils.Colorize("'unsafe-inline'", "magenta", true)+" allows the execution of unsafe in-page scripts and event handlers.\n", directive)
-			redissues++
+			response.Status = Error
+			response.ConsoleMessages = append(response.ConsoleMessages, utils.Colorize("Content-Security-Policy", "red", true)+" dangerous source in "+utils.Colorize(directive+": ", "", true)+utils.Colorize("'unsafe-inline'", "magenta", true)+" allows the execution of unsafe in-page scripts and event handlers.")
+			response.Messages = append(response.Messages, "Dangerous source in "+directive+": 'unsafe-inline' allows the execution of unsafe in-page scripts and event handlers.")
 		case "data":
-			fmt.Print(utils.Colorize("Content-Security-Policy", "red", true)+" dangerous source in "+utils.Colorize("%s: ", "", true)+utils.Colorize("'data:'", "", true)+" URI allows the execution of unsafe scripts.\n", directive)
-			redissues++
+			response.Status = Error
+			response.ConsoleMessages = append(response.ConsoleMessages, utils.Colorize("Content-Security-Policy", "red", true)+" dangerous source in "+utils.Colorize(directive+": ", "", true)+utils.Colorize("'data:'", "", true)+" URI allows the execution of unsafe scripts.")
+			response.Messages = append(response.Messages, "Dangerous source in "+directive+": 'data:' URI allows the execution of unsafe scripts.")
 		case "*":
-			fmt.Print(utils.Colorize("Content-Security-Policy", "red", true)+" dangerous source in "+utils.Colorize("%s: ", "", true)+"should not allow "+utils.Colorize("'*'", "", true)+" as a source.\n", directive)
-			redissues++
+			response.Status = Error
+			response.ConsoleMessages = append(response.ConsoleMessages, utils.Colorize("Content-Security-Policy", "red", true)+" dangerous source in "+utils.Colorize(directive+": ", "", true)+"should not allow "+utils.Colorize("'*'", "", true)+" as a source.")
+			response.Messages = append(response.Messages, "Dangerous source in "+directive+": '*' should not be allowed as a source.")
 		case "http:":
-			fmt.Print(utils.Colorize("Content-Security-Policy", "red", true)+" dangerous source in "+utils.Colorize("%s: ", "", true)+utils.Colorize("'http:'", "magenta", true)+" allows the execution of unsafe scripts.\n", directive)
-			redissues++
+			response.Status = Error
+			response.ConsoleMessages = append(response.ConsoleMessages, utils.Colorize("Content-Security-Policy", "red", true)+" dangerous source in "+utils.Colorize(directive+": ", "", true)+utils.Colorize("'http:'", "magenta", true)+" allows the execution of unsafe scripts.")
+			response.Messages = append(response.Messages, "Dangerous source in "+directive+": 'http:' allows the execution of unsafe scripts.")
 		case "https:":
-			fmt.Print(utils.Colorize("Content-Security-Policy", "red", true)+" dangerous source in "+utils.Colorize("%s: ", "", true)+utils.Colorize("'https:'", "magenta", true)+" allows the execution of unsafe scripts.\n", directive)
-			redissues++
+			response.Status = Error
+			response.ConsoleMessages = append(response.ConsoleMessages, utils.Colorize("Content-Security-Policy", "red", true)+" dangerous source in "+utils.Colorize(directive+": ", "", true)+utils.Colorize("'https:'", "magenta", true)+" allows the execution of unsafe scripts.")
+			response.Messages = append(response.Messages, "Dangerous source in "+directive+": 'https:' allows the execution of unsafe scripts.")
 		default:
 			parsedURL, err := url.Parse(source)
 			if err != nil {
-				fmt.Println("Error parsing URL:", err)
+				response.Status = Error
+				response.ConsoleMessages = append(response.ConsoleMessages, utils.Colorize("Content-Security-Policy", "red", true)+" invalid source in "+utils.Colorize(directive+": ", "", true)+utils.Colorize(source, "magenta", true))
+				response.Messages = append(response.Messages, "Invalid source in "+directive+": "+source)
 			} else {
 				if parsedURL.Scheme == "http" || parsedURL.Scheme == "https" {
 					if parsedURL.Host != "" {
-						fmt.Printf(utils.Colorize("Content-Security-Policy", "yellow", true)+" possible dangerous source in "+utils.Colorize("%s: ", "", true)+"Make sure that "+utils.Colorize(source, "blue", true)+" is not hosting JSONP endpoints\n", directive)
-						yellowissues++
+						if response.Status != Error {
+							response.Status = Warning
+						}
+						response.ConsoleMessages = append(response.ConsoleMessages, utils.Colorize("Content-Security-Policy", "yellow", true)+" possible dangerous source in "+utils.Colorize(directive+": ", "", true)+"Make sure that "+utils.Colorize(source, "blue", true)+" is not hosting JSONP endpoints")
+						response.Messages = append(response.Messages, "Possible dangerous source in "+directive+": "+source+" is hosting JSONP endpoints.")
 					}
 				} else if nonHttpUrlPattern.MatchString(source) {
-					fmt.Printf(utils.Colorize("Content-Security-Policy", "yellow", true)+" possible dangerous source in "+utils.Colorize("%s: ", "", true)+"Make sure that "+utils.Colorize(source, "blue", true)+" is not hosting JSONP endpoints\n", directive)
-					yellowissues++
+					if response.Status != Error {
+						response.Status = Warning
+					}
+					response.ConsoleMessages = append(response.ConsoleMessages, utils.Colorize("Content-Security-Policy", "yellow", true)+" possible dangerous source in "+utils.Colorize(directive+": ", "", true)+"Make sure that "+utils.Colorize(source, "blue", true)+" is not hosting JSONP endpoints")
+					response.Messages = append(response.Messages, "Possible dangerous source in "+directive+": "+source+" is hosting JSONP endpoints.")
 				}
 			}
 		}

--- a/auditor/auditorhandler.go
+++ b/auditor/auditorhandler.go
@@ -1,6 +1,7 @@
 package auditor
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"net/http"
@@ -37,13 +38,43 @@ type RequestMethod struct {
 	Body string
 }
 
-var redissues, yellowissues int = 0, 0
+type ResponseStatus int64
 
-func (target *Target) ProcessTarget(multi bool) {
+const (
+	Error ResponseStatus = iota
+	Warning
+	Success
+)
+
+func (rs ResponseStatus) String() string {
+	return [...]string{"Error", "Warning", "Success"}[rs]
+}
+
+func (rs ResponseStatus) MarshalJSON() ([]byte, error) {
+	buffer := bytes.NewBufferString(`"`)
+	buffer.WriteString([...]string{"Error", "Warning", "Success"}[rs])
+	buffer.WriteString(`"`)
+	return buffer.Bytes(), nil
+}
+
+type HeaderResponse struct {
+	Header          string
+	Status          ResponseStatus
+	Messages        []string
+	ConsoleMessages []string `json:"-"`
+}
+
+type TargetResponse struct {
+	URL       string
+	Responses []HeaderResponse
+	Status    ResponseStatus
+}
+
+func (target *Target) ProcessTarget(multi bool) (bool, TargetResponse) {
 	resp, err := doRequest(target, target.Method.Verb)
 	if err != nil {
 		fmt.Printf("error in performing HTTP request to the target: %v", err)
-		return
+		return false, TargetResponse{}
 	}
 
 	if multi {
@@ -52,7 +83,33 @@ func (target *Target) ProcessTarget(multi bool) {
 	}
 	fmt.Printf("\nAnalyzing "+utils.Colorize("%s", "blue", true)+" security headers\n\n", target.URL)
 
-	handleResponse(target, resp)
+	ok, responses := handleResponse(target, resp)
+	if !ok {
+		return false, TargetResponse{}
+	}
+
+	// calculate the status of the target based on the status of each header
+	var status ResponseStatus
+	for _, response := range responses {
+		if response.Status == Error {
+			status = Error
+			break
+		} else if response.Status == Warning && status != Error {
+			status = Warning
+		} else if response.Status == Success && status != Error && status != Warning {
+			status = Success
+		}
+	}
+
+	if status == Success {
+		fmt.Printf(utils.Colorize("No security header issues found for %v\n", "green", true), target.URL)
+	}
+
+	return true, TargetResponse{
+		URL:       target.URL,
+		Responses: responses,
+		Status:    status,
+	}
 }
 
 func doRequest(target *Target, method string) (*http.Response, error) {
@@ -76,18 +133,18 @@ func doRequest(target *Target, method string) (*http.Response, error) {
 	return resp, nil
 }
 
-func handleResponse(target *Target, resp *http.Response) {
+func handleResponse(target *Target, resp *http.Response) (bool, []HeaderResponse) {
 	if resp.StatusCode == http.StatusForbidden {
 		req, err := http.NewRequest(target.Method.Verb, target.URL, strings.NewReader(target.Method.Body))
 		if err != nil {
 			fmt.Printf("Error creating a %s request for %s: %v\n", target.Method.Verb, target.URL, err)
-			return
+			return false, nil
 		}
 
 		err = setHeaders(req, target.Cookie, target.Header)
 		if err != nil {
 			fmt.Println(err)
-			return
+			return false, nil
 		}
 
 		req.Header.Set("User-Agent", "curl/7.81.0")
@@ -95,34 +152,36 @@ func handleResponse(target *Target, resp *http.Response) {
 		resp, err = target.Client.Do(req)
 		if err != nil {
 			fmt.Println(err)
-			return
+			return false, nil
 		}
 		defer resp.Body.Close()
 	}
 
 	if resp.StatusCode < http.StatusBadRequest {
-		auditHeaders(resp.Header, target.URL)
+		return true, auditHeaders(resp.Header)
 	} else {
-		retryGet(target)
+		return retryGet(target)
 	}
 }
 
-func retryGet(target *Target) {
+func retryGet(target *Target) (bool, []HeaderResponse) {
 
 	getResp, err := doRequest(target, http.MethodGet)
 	if err != nil {
 		fmt.Printf("Error: %v\n", err)
-		return
+		return false, nil
 	}
 
 	if getResp.StatusCode >= http.StatusBadRequest {
 		fmt.Printf("Error making the GET request to %s : \"%v\" HTTP Error code\n\n", target.URL, getResp.Status)
+		return false, nil
 	} else {
-		auditHeaders(getResp.Header, target.URL)
+		return true, auditHeaders(getResp.Header)
 	}
 }
 
-func auditHeaders(resphdrs http.Header, targetURL string) {
+func auditHeaders(resphdrs http.Header) []HeaderResponse {
+	var responses []HeaderResponse = []HeaderResponse{}
 
 	normalizedResphdrs := make(map[string][]string)
 	for key, values := range resphdrs {
@@ -133,23 +192,20 @@ func auditHeaders(resphdrs http.Header, targetURL string) {
 
 		switch sechdr {
 		case XFrameOptionsHeader:
-			xFrameOptionsAudit(normalizedResphdrs)
+			responses = append(responses, xFrameOptionsAudit(normalizedResphdrs))
 
 		case XContentTypeOptionsHeader:
-			xContentTypeOptionsAudit(normalizedResphdrs)
+			responses = append(responses, xContentTypeOptionsAudit(normalizedResphdrs))
 
 		case StrictTransportSecurityHeader:
-			strictTransportSecurityAudit(normalizedResphdrs)
+			responses = append(responses, strictTransportSecurityAudit(normalizedResphdrs))
 
 		case ContentSecurityPolicyHeader:
-			contentSecurityPolicyAudit(normalizedResphdrs)
+			responses = append(responses, contentSecurityPolicyAudit(normalizedResphdrs))
 		}
 	}
 
-	if redissues == 0 && yellowissues == 0 {
-		fmt.Printf(utils.Colorize("No security header issues found for %v\n", "green", true), targetURL)
-	}
-	redissues, yellowissues = 0, 0
+	return responses
 }
 
 func setHeaders(req *http.Request, cookie, customHeader string) error {

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/trap-bytes/hauditor
 
-go 1.21.5
+go 1.21

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -190,6 +190,7 @@ func PrintHelp() {
 	fmt.Println("  -c string    Specify cookies (e.g., \"user_token=g3p21ip21h;\" ")
 	fmt.Println("  -r string    Specify headers (e.g., \"Myheader: test\")")
 	fmt.Println("  -timeout     Specify connection timeout in seconds (Default 10)")
+	fmt.Println("  -j           Output results in JSON format")
 	fmt.Println("  -h           Display help")
 
 	fmt.Println("\nExamples:")


### PR DESCRIPTION
I implemented the JSON output for the CLI so when the flag `-j` is used, the output in the console is a valid JSON, i.e.:

```sh
go run main.go -t facebook.com -j
  {
    "URL": "https://facebook.com/",
    "Responses": [
      {
        "Header": "x-frame-options",
        "Status": "Success",
        "Messages": null
      },
      {
        "Header": "x-content-type-options",
        "Status": "Success",
        "Messages": null
      },
      {
        "Header": "strict-transport-security",
        "Status": "Success",
        "Messages": null
      },
      {
        "Header": "content-security-policy",
        "Status": "Error",
        "Messages": [
          "Possible dangerous source in script-src: *.facebook.com is hosting JSONP endpoints.",
          "Possible dangerous source in script-src: *.fbcdn.net is hosting JSONP endpoints.",
          "Dangerous source in script-src: 'unsafe-inline' allows the execution of unsafe in-page scripts and event handlers."
        ]
      }
    ],
    "Status": "Error"
  }
```

## Implementation

To implement the JSON output, I needed to store the messages in some structs rather than printing them on the shell, so finally it's the `main.go` file that decides what to output on the shell: a JSON string or a list of colored messages.

The 2 struct used:
```go
type HeaderResponse struct {
	Header          string
	Status          ResponseStatus
	Messages        []string
	ConsoleMessages []string `json:"-"`
}

type TargetResponse struct {
	URL       string
	Responses []HeaderResponse
	Status    ResponseStatus
}
```

There is also a hack concerning some info print (like the banner): to handle those prints I disabled the print at the beginning of main with `os.Stdout = nil` and then I restored it before printing the output.

Other options would be creating some logging function or wrapping each print in `if jsonOutput {}`.

PR for issue #2 